### PR TITLE
remove deprecated config option

### DIFF
--- a/content/posts/set-up-voi-participation-node/index.md
+++ b/content/posts/set-up-voi-participation-node/index.md
@@ -221,7 +221,6 @@ Expected last line of output: `OK`
 
 ```bash
 sudo algocfg set -p DNSBootstrapID -v "<network>.voi.network" -d /var/lib/algorand/ &&\
-sudo algocfg set -p EnableCatchupFromArchiveServers -v true -d /var/lib/algorand/ &&\
 sudo chown algorand:algorand /var/lib/algorand/config.json &&\
 sudo chmod g+w /var/lib/algorand/config.json &&\
 echo OK


### PR DESCRIPTION
EnableCatchupFromArchiveServers no longer used as of https://github.com/algorand/go-algorand/commit/86319605bebbc2d48f68b6d4360ebc917e018e85